### PR TITLE
UL: Handle compatibility writes correctly

### DIFF
--- a/Firmware/Chameleon-Mini/Application/MifareUltralight.c
+++ b/Firmware/Chameleon-Mini/Application/MifareUltralight.c
@@ -285,7 +285,7 @@ static uint16_t AppProcess(uint8_t *const Buffer, uint16_t ByteCount) {
 
         //Handle MF ULC counter
         if (CompatWritePageAddress == MF_ULC_COUNTER_ADDRESS && Flavor == UL_C) {
-            if (IncrementCounter(&Buffer[2])) {
+            if (IncrementCounter(&Buffer[0])) {
                 Buffer[0] = ACK_VALUE;
                 return ACK_FRAME_SIZE;
             } else {
@@ -294,7 +294,7 @@ static uint16_t AppProcess(uint8_t *const Buffer, uint16_t ByteCount) {
             }
         }
 
-        AppWritePage(CompatWritePageAddress, &Buffer[2]);
+        AppWritePage(CompatWritePageAddress, &Buffer[0]);
         Buffer[0] = ACK_VALUE;
         return ACK_FRAME_SIZE;
     }


### PR DESCRIPTION
This PR fixes an issue with compatibility writes to Mifare Ultralight where bytes 2-6 are written to the block instead of 0-4.

Before:

![](https://lasagna.cat/i/11hgheb9.png)

After:

![](https://lasagna.cat/i/s3y6q22g.png)