### PR TITLE
Create initial CI configuration

### DIFF
--- a/.github/workflows/firmware.yml
+++ b/.github/workflows/firmware.yml
@@ -1,0 +1,39 @@
+name: Firmware Build
+
+on:
+  push:
+    paths:
+      - "Firmware/**"
+  pull_request:
+    paths:
+      - "Firmware/**"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cleanup similar named things from root
+      run: rm Chameleon*
+    - name: Print Kernel Ver
+      run: uname -a
+    - name: Update APT
+      run: sudo apt-get update -yqq
+    - name: Install AVR GCC Suite
+      run: sudo apt-get install -yqq make autoconf build-essential ca-certificates pkg-config libreadline-dev gcc-avr binutils-avr gdb-avr avr-libc avrdude
+    - name: Make Firmware
+      run: make
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Move hex file to root
+      run: mv Chameleon*.hex $GITHUB_WORKSPACE/
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Move eep file to root
+      run: mv Chameleon*.eep $GITHUB_WORKSPACE/
+      working-directory: Firmware/Chameleon-Mini/
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v2.1.4
+      with:
+        name: "ChameleonBuild"
+        path: "Chameleon*.*"


### PR DESCRIPTION
Builds and bundles the firmware build as an artifact.

Release automation is not included.

This PR may not trigger the CI.